### PR TITLE
Issue 25 - Allow running server on 'older' node

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,9 @@ var app = express();
 
 app.use(function forceSSL(req, res, next) {
   var host = req.get('Host');
-  if (!host.startsWith('localhost')) {
+  var localhost = 'localhost';
+
+  if (host.substring(0, localhost.length) !== localhost) {
     // https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security
     res.header('Strict-Transport-Security', 'max-age=15768000');
     // https://github.com/rangle/force-ssl-heroku/blob/master/force-ssl-heroku.js


### PR DESCRIPTION
Fixes issue #25 ; server will now start on 0.12.7, for example.