### PR TITLE
Allow Analytics example to work better within cookbook site iframe

### DIFF
--- a/api-analytics/index.js
+++ b/api-analytics/index.js
@@ -45,6 +45,11 @@ function showQuotations(collection) {
     quote = collection[index];
     table.appendChild(getRowFor(quote));
   }
+
+  // Specifically for the cookbook site :(
+  if (window.parent !== window) {
+    window.parent.document.body.dispatchEvent(new CustomEvent('iframeresize'));
+  }
 }
 
 // Builds a row for a quote.

--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -1,7 +1,7 @@
 'use strict';
 
-function resizeIframe(obj) {
-  obj.style.height = obj.contentWindow.document.body.scrollHeight + 'px';
+function resizeIframe(iframe) {
+  iframe.style.height = iframe.contentWindow.document.body.scrollHeight + 'px';
 }
 
 (function() {
@@ -29,3 +29,15 @@ function resizeIframe(obj) {
 window.addEventListener('load', function() {
   document.body.classList.add('loaded');
 });
+
+(function()  {
+  var iframe = document.querySelector('iframe');
+  var callback = function () {
+    resizeIframe(iframe);
+  };
+
+  if(iframe) {
+    document.body.addEventListener('iframeresize', callback);
+    iframe.addEventListener('load', callback);
+  }
+})();

--- a/src/tpl/demo.html
+++ b/src/tpl/demo.html
@@ -1,2 +1,2 @@
 <h1>{{ recipe.name }} Demo</h1>
-<iframe src="{{ recipe.slug }}/index.html" style="width: 100%;" scrolling="no" onload="resizeIframe(this);"></iframe>
+<iframe src="{{ recipe.slug }}/index.html" style="width: 100%;" scrolling="no"></iframe>


### PR DESCRIPTION
This isn't optimal but I'm struggling for a better solution.  The "Analytics API" demo appears wrong because the table gets populated after page load.

I'm really hoping there's an easier, cleaner solution that I'm not seeing.