### PR TITLE
Add 'slash' to cache

### DIFF
--- a/offline-status/service-worker.js
+++ b/offline-status/service-worker.js
@@ -12,6 +12,7 @@ var REQUIRED_FILES = [
   'random-6.png',
   'style.css',
   'index.html',
+  '/',
   'index.js',
   'app.js'
 ];


### PR DESCRIPTION
Reported:  https://twitter.com/hsablonniere/status/667425018779975680

Seems kinda odd, but I guess not.  Could be 'index.php' or something.

Let me know what you think.