### PR TITLE
Registration is now more accurate, loading quotations only when the active worker enters the game.

### DIFF
--- a/api-analytics/README.md
+++ b/api-analytics/README.md
@@ -12,4 +12,4 @@ As a web app developer, I want to add API tracking capabilities to my web applic
 With the use of a service worker, we intercept each request of a client and send some information to a log API.
 
 ## Category
-Misc
+More than offline

--- a/api-analytics/index.js
+++ b/api-analytics/index.js
@@ -1,13 +1,25 @@
 var ENDPOINT = 'api/quotations';
 
 // Register the worker and show the list of quotations.
-navigator.serviceWorker.register('service-worker.js').then(function() {
+if (navigator.serviceWorker.controller) {
   loadQuotations();
-});
+} else {
+  navigator.serviceWorker.oncontrollerchange = function() {
+    this.controller.onstatechange = function() {
+      if (this.state === 'activated') {
+        loadQuotations();
+      }
+    };
+  };
+  navigator.serviceWorker.register('service-worker.js');
+}
 
 // When clicking add button, get the new quote and author and post to
 // the backend.
-document.getElementById('add-form').onsubmit = function() {
+document.getElementById('add-form').onsubmit = function(event) {
+  // Avoid navigation
+  event.preventDefault();
+
   var newQuote = document.getElementById('new-quote').value.trim();
   // Skip if no quote provided.
   if (!newQuote) { return; }

--- a/api-analytics/server.js
+++ b/api-analytics/server.js
@@ -59,7 +59,9 @@ module.exports = function(app, route) {
 
   // Returns an array with all quotations.
   app.get(route + 'api/quotations', function(req, res) {
-    res.json(quotations);
+    res.json(quotations.filter(function(item) {
+      return item !== null;
+    }));
   });
 
   // Delete a quote specified by id. The id is the position in the collection
@@ -67,7 +69,7 @@ module.exports = function(app, route) {
   app.delete(route + 'api/quotations/:id', function(req, res) {
     var id = parseInt(req.params.id, 10) - 1;
     if (!quotations[id].isSticky) {
-      quotations.splice(id, 1);
+      quotations[id] = null;
     }
     res.sendStatus(204);
   });

--- a/api-analytics/service-worker.js
+++ b/api-analytics/service-worker.js
@@ -7,7 +7,7 @@ self.oninstall = function(event) {
   event.waitUntil(self.skipWaiting());
 };
 
-self.onactive = function(event) {
+self.onactivate = function(event) {
   event.waitUntil(self.clients.claim());
 };
 


### PR DESCRIPTION
claim() now succeed, before it was in an useless event handler.
Deletion of quotations does not fail now.
Category has been changed to More than offline
Navigation prevented after adding a new quote.

Fix #130