### PR TITLE
Remove travis-scripts from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "homepage": "https://mozilla.github.com/serviceworker-cookbook/",
   "devDependencies": {
-    "@alrra/travis-scripts": "^1.1.1",
     "browser-sync": "^2.9.6",
     "del": "^2.0.2",
     "eslint": "^1.10.3",


### PR DESCRIPTION
It isn't really needed to build serviceworker-cookbook, it's more of a tool for developers, so we shouldn't force its installation (who wants to use it, can install it globally).