### PR TITLE
Run lint when building

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -204,7 +204,7 @@ gulp.task('build:favicon', ['clean'], function() {
 });
 
 // Start express server after building site
-gulp.task('start-server', ['build'], function startServer(cb) {
+gulp.task('start-server', ['build', 'lint'], function startServer(cb) {
   require('./server.js').ready.then(cb);
 });
 
@@ -225,4 +225,4 @@ gulp.task('test', ['lint']);
 gulp.task('build-dev', ['build:recipes', 'test']);
 
 // Full build for publishing
-gulp.task('build', ['build-dev', 'build:index', 'build:intros', 'build:demos', 'build:docs', 'build:css', 'build:js', 'build:tabzilla', 'build:favicon']);
+gulp.task('build', ['build:index', 'build:intros', 'build:demos', 'build:recipes', 'build:docs', 'build:css', 'build:js', 'build:tabzilla', 'build:favicon']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -225,4 +225,4 @@ gulp.task('test', ['lint']);
 gulp.task('build-dev', ['build:recipes', 'test']);
 
 // Full build for publishing
-gulp.task('build', ['build:index', 'build:intros', 'build:demos', 'build:recipes', 'build:docs', 'build:css', 'build:js', 'build:tabzilla', 'build:favicon']);
+gulp.task('build', ['build-dev', 'build:index', 'build:intros', 'build:demos', 'build:docs', 'build:css', 'build:js', 'build:tabzilla', 'build:favicon']);


### PR DESCRIPTION
I use `gulp start-server` while developing, which depends on `build`. `build` doesn't depend on `test` and on `lint` though, so I often forget to run `lint`.