### PR TITLE
Update web-push dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "glob": "^7.0.0",
     "request": "^2.64.0",
     "swig": "^1.4.2",
-    "web-push": "^1.0.1"
+    "web-push": "^2.0.0"
   },
   "engines": {
     "node": "4"

--- a/push-clients/server.js
+++ b/push-clients/server.js
@@ -14,7 +14,9 @@ module.exports = function(app, route) {
 
   app.post(route + 'sendNotification', function(req, res) {
     setTimeout(function() {
-      webPush.sendNotification(req.query.endpoint, 200)
+      webPush.sendNotification(req.query.endpoint, {
+        TTL: 200,
+      })
       .then(function() {
         res.sendStatus(201);
       });

--- a/push-get-payload/server.js
+++ b/push-get-payload/server.js
@@ -17,7 +17,9 @@ module.exports = function(app, route) {
   app.post(route + 'sendNotification', function(req, res) {
     setTimeout(function() {
       payloads[req.body.endpoint] = req.body.payload;
-      webPush.sendNotification(req.body.endpoint, req.body.ttl)
+      webPush.sendNotification(req.body.endpoint, {
+        TTL: req.body.ttl,
+      })
       .then(function() {
         res.sendStatus(201);
       });

--- a/push-payload/index.js
+++ b/push-payload/index.js
@@ -1,5 +1,6 @@
 var endpoint;
 var key;
+var authSecret;
 
 // Register a Service Worker.
 navigator.serviceWorker.register('service-worker.js')
@@ -22,6 +23,10 @@ navigator.serviceWorker.register('service-worker.js')
   key = rawKey ?
         btoa(String.fromCharCode.apply(null, new Uint8Array(rawKey))) :
         '';
+  var rawAuthSecret = subscription.getKey ? subscription.getKey('auth') : '';
+  authSecret = rawAuthSecret ?
+               btoa(String.fromCharCode.apply(null, new Uint8Array(rawAuthSecret))) :
+               '';
 
   endpoint = subscription.endpoint;
 
@@ -34,6 +39,7 @@ navigator.serviceWorker.register('service-worker.js')
     body: JSON.stringify({
       endpoint: subscription.endpoint,
       key: key,
+      authSecret: authSecret,
     }),
   });
 });
@@ -54,6 +60,7 @@ document.getElementById('doIt').onclick = function() {
     body: JSON.stringify({
       endpoint: endpoint,
       key: key,
+      authSecret: authSecret,
       payload: payload,
       delay: delay,
       ttl: ttl,

--- a/push-payload/server.js
+++ b/push-payload/server.js
@@ -14,8 +14,12 @@ module.exports = function(app, route) {
 
   app.post(route + 'sendNotification', function(req, res) {
     setTimeout(function() {
-      webPush.sendNotification(req.body.endpoint, req.body.ttl, req.body.key,
-                               req.body.payload)
+      webPush.sendNotification(req.body.endpoint, {
+        TTL: req.body.ttl,
+        payload: req.body.payload,
+        userPublicKey: req.body.key,
+        userAuth: req.body.authSecret,
+      })
       .then(function() {
         res.sendStatus(201);
       });

--- a/push-quota/index.js
+++ b/push-quota/index.js
@@ -1,5 +1,6 @@
 var endpoint;
 var key;
+var authSecret;
 
 // Register a Service Worker.
 navigator.serviceWorker.register('service-worker.js')
@@ -23,6 +24,10 @@ navigator.serviceWorker.register('service-worker.js')
   key = rawKey ?
         btoa(String.fromCharCode.apply(null, new Uint8Array(rawKey))) :
         '';
+  var rawAuthSecret = subscription.getKey ? subscription.getKey('auth') : '';
+  authSecret = rawAuthSecret ?
+               btoa(String.fromCharCode.apply(null, new Uint8Array(rawAuthSecret))) :
+               '';
 
   endpoint = subscription.endpoint;
 
@@ -35,6 +40,7 @@ navigator.serviceWorker.register('service-worker.js')
     body: JSON.stringify({
       endpoint: subscription.endpoint,
       key: key,
+      authSecret: authSecret,
     }),
   });
 });
@@ -52,6 +58,7 @@ function askForNotifications(visible) {
     body: JSON.stringify({
       endpoint: endpoint,
       key: key,
+      authSecret: authSecret,
       visible: visible,
       num: notificationNum,
     }),

--- a/push-quota/server.js
+++ b/push-quota/server.js
@@ -22,10 +22,12 @@ module.exports = function(app, route) {
     var promises = [];
 
     var intervalID = setInterval(function() {
-      promises.push(webPush.sendNotification(req.body.endpoint,
-                                             200,
-                                             req.body.key,
-                                             JSON.stringify(req.body.visible)));
+      promises.push(webPush.sendNotification(req.body.endpoint, {
+        TTL: 200,
+        payload: JSON.stringify(req.body.visible),
+        userPublicKey: req.body.key,
+        userAuth: req.body.authSecret,
+      }));
 
       if (num++ === Number(req.body.num)) {
         clearInterval(intervalID);

--- a/push-replace/server.js
+++ b/push-replace/server.js
@@ -13,10 +13,14 @@ module.exports = function(app, route) {
   });
 
   app.post(route + 'sendNotification', function(req, res) {
-    webPush.sendNotification(req.query.endpoint, 200);
+    webPush.sendNotification(req.query.endpoint, {
+      TTL: 200,
+    });
 
     setTimeout(function() {
-      webPush.sendNotification(req.query.endpoint, 200)
+      webPush.sendNotification(req.query.endpoint, {
+        TTL: 200,
+      })
       .then(function() {
         res.sendStatus(201);
       });

--- a/push-rich/server.js
+++ b/push-rich/server.js
@@ -14,7 +14,9 @@ module.exports = function(app, route) {
 
   app.post(route + 'sendNotification', function(req, res) {
     setTimeout(function() {
-      webPush.sendNotification(req.query.endpoint, req.query.ttl)
+      webPush.sendNotification(req.query.endpoint, {
+        TTL: req.query.ttl,
+      })
       .then(function() {
         res.sendStatus(201);
       });

--- a/push-simple/server.js
+++ b/push-simple/server.js
@@ -14,7 +14,9 @@ module.exports = function(app, route) {
 
   app.post(route + 'sendNotification', function(req, res) {
     setTimeout(function() {
-      webPush.sendNotification(req.query.endpoint, req.query.ttl)
+      webPush.sendNotification(req.query.endpoint, {
+        TTL: req.query.ttl,
+      })
       .then(function() {
         res.sendStatus(201);
       });


### PR DESCRIPTION
This adds support for Chrome 50+ to the `push-payload` and the `push-quota` recipes. Also, it's needed for VAPID (#218).