### PR TITLE
Delete the Chrome Warnings

### DIFF
--- a/message-relay/README.md
+++ b/message-relay/README.md
@@ -2,8 +2,6 @@
 
 This recipe shows how to communicate between the service worker and a page and shows how to use a service worker to relay messages between pages.
 
-**Warning:** this recipe doesn't fully work in Chrome yet (because of [this issue](https://code.google.com/p/chromium/issues/detail?id=549346)).  Read the source code of the recipe for more details.
-
 ## Difficulty
 Beginner
 

--- a/message-relay/index.html
+++ b/message-relay/index.html
@@ -13,7 +13,6 @@
   </style>
 </head>
 <body>
-<p><b>Warning:</b> this demo doesn't fully work in Chrome yet (because of <a href="https://code.google.com/p/chromium/issues/detail?id=549346" target="_blank">this issue</a>). Read the source code of the recipe for more details.</p>
 
 <div>
   Service Worker Status: <span id="status">not supported</span>


### PR DESCRIPTION
I noticed that the example worked on Chrome so I took a peak and it appears that it is fixed as of Chrome M51:

https://bugs.chromium.org/p/chromium/issues/detail?id=543198