### PR TITLE
Allow startup without setting GCM API key

### DIFF
--- a/push-rich/server.js
+++ b/push-rich/server.js
@@ -4,7 +4,7 @@
 // https://tools.ietf.org/html/draft-ietf-webpush-encryption.
 var webPush = require('web-push');
 
-webPush.setGCMAPIKey(process.env.GCM_API_KEY);
+webPush.setGCMAPIKey(process.env.GCM_API_KEY || null);
 
 module.exports = function(app, route) {
   app.post(route + 'register', function(req, res) {


### PR DESCRIPTION
Noticed that this was blocking startup, so made a fix that seemed to be in line with recent progress on this issue.