### PR TITLE
Added local download example

### DIFF
--- a/local-download/README.md
+++ b/local-download/README.md
@@ -6,9 +6,11 @@ Allow a user to "download" a file that's been generated on the client side.
 Beginner
 
 ## Use Case
-Often it will be necessary to include a download feature in a single page application - for example, a draw program might want the ability to export as SVG, or a map 
+Often it will be necessary to include a download feature in a single page application - for example, a drawing program might want the ability to export as SVG, or a bitmap format generated client side.
 
-Because serviceworkers can respond to POST events, this allows us to attach the data to a POST operation. The service worker then pulls the data off of the request and returns it to the user as a file.
+
+## Solution
+Using the serviceworker to intercept a form POST operation, pull the data from the body of the request. The data can then be put in a request that behaves as a downloadable attachment, which is fed back to the client as a file. The file will appear to have been downloaded, without any round trips to the server necessary.
 
 ## Category
 Beyond Offline

--- a/local-download/README.md
+++ b/local-download/README.md
@@ -1,0 +1,14 @@
+# Local Download
+
+Allow a user to "download" a file that's been generated on the client side. 
+
+## Difficulty
+Beginner
+
+## Use Case
+Often it will be necessary to include a download feature in a single page application - for example, a draw program might want the ability to export as SVG, or a map 
+
+Because serviceworkers can respond to POST events, this allows us to attach the data to a POST operation. The service worker then pulls the data off of the request and returns it to the user as a file.
+
+## Category
+Beyond Offline

--- a/local-download/README.md
+++ b/local-download/README.md
@@ -8,7 +8,6 @@ Beginner
 ## Use Case
 Often it will be necessary to include a download feature in a single page application - for example, a drawing program might want the ability to export as SVG, or a bitmap format generated client side.
 
-
 ## Solution
 Using the serviceworker to intercept a form POST operation, pull the data from the body of the request. The data can then be put in a request that behaves as a downloadable attachment, which is fed back to the client as a file. The file will appear to have been downloaded, without any round trips to the server necessary.
 

--- a/local-download/index.html
+++ b/local-download/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Local Download - ServiceWorker Cookbook</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body {
+      font-family: monospace;
+      font-size: 1rem;
+      white-space: pre-wrap;
+    }
+  </style>
+</head>
+<body>
+  <form action="download-file" method="POST">  
+  <label for="filename">Choose a name for the file.</label>
+  <input type="text" name="filename" value="textfile.txt" />
+  <textarea name="filebody" id="filebody">
+    Click below to download this message as a text file.
+  </textarea>
+  <input type="submit" id="download" value="Download"/>
+  </form>
+
+  
+<script src="./index.js"></script>
+</body>
+</html>

--- a/local-download/index.html
+++ b/local-download/index.html
@@ -14,12 +14,19 @@
 </head>
 <body>
   <form action="download-file" method="POST">  
-  <label for="filename">Choose a name for the file.</label>
-  <input type="text" name="filename" value="textfile.txt" />
-  <textarea name="filebody" id="filebody">
-    Click below to download this message as a text file.
-  </textarea>
-  <input type="submit" id="download" value="Download"/>
+  <label for="filename">
+    Choose a name for the file.
+    <input type="text" name="filename" value="textfile.txt" />
+  </label>
+  <label> 
+    Fill out file contents
+    <textarea name="filebody" id="filebody" rows="12" cols="80">
+Click below to download this message as a text file.
+    </textarea>
+  </label>
+  <div>
+    <input class="button" type="submit" id="download" value="Download this file"/>
+  </div>
   </form>
   <script src="./index.js"></script>
 </body>

--- a/local-download/index.html
+++ b/local-download/index.html
@@ -21,8 +21,6 @@
   </textarea>
   <input type="submit" id="download" value="Download"/>
   </form>
-
-  
-<script src="./index.js"></script>
+  <script src="./index.js"></script>
 </body>
 </html>

--- a/local-download/index.js
+++ b/local-download/index.js
@@ -1,10 +1,4 @@
 // Register the ServiceWorker
 navigator.serviceWorker.register('service-worker.js', {
   scope: '.'
-}).then(function(registration) {
-  console.log('The service worker has been registered ', registration);
-  var content = document.getElementById("text");
-  var button = document.getElementById("download");
-
-});
-
+})

--- a/local-download/index.js
+++ b/local-download/index.js
@@ -1,0 +1,10 @@
+// Register the ServiceWorker
+navigator.serviceWorker.register('service-worker.js', {
+  scope: '.'
+}).then(function(registration) {
+  console.log('The service worker has been registered ', registration);
+  var content = document.getElementById("text");
+  var button = document.getElementById("download");
+
+});
+

--- a/local-download/service-worker.js
+++ b/local-download/service-worker.js
@@ -1,0 +1,15 @@
+// [Working example](/serviceworker-cookbook/DIR-HERE/).
+
+self.addEventListener('fetch', function(event) {
+    // If the request is going to the download-file endpoint, parse the post data and return a file. 
+    // This can be paired with a server side function with the same behavior as a fallback.
+    if(event.request.url.indexOf("download-file") != -1) {
+        event.respondWith(event.request.formData().then(function (formdata){
+                    var filename = formdata.get("filename");
+                    var body = formdata.get("filebody");
+                    var response = new Response(body);
+                    response.headers.append('Content-Disposition', 'attachment; filename="' + filename + '"');
+                    return response;
+                }));
+    }
+});

--- a/local-download/service-worker.js
+++ b/local-download/service-worker.js
@@ -2,15 +2,15 @@
 
 // Listen on fetch events for posts to download-file
 self.addEventListener('fetch', function(event) {
-    // If the request is going to the download-file endpoint, parse the post data and return a file. 
-    // This can be paired with a server side function with the same behavior as a fallback.
-    if(event.request.url.indexOf("download-file") !== -1) {
-        event.respondWith(event.request.formData().then(function (formdata){
-                    var filename = formdata.get("filename");
-                    var body = formdata.get("filebody");
-                    var response = new Response(body);
-                    response.headers.append('Content-Disposition', 'attachment; filename="' + filename + '"');
-                    return response;
-                }));
+  // If the request is going to the download-file endpoint, parse the post data and return a file. 
+  // This can be paired with a server side function with the same behavior as a fallback.
+  if(event.request.url.indexOf("download-file") !== -1) {
+    event.respondWith(event.request.formData().then(function (formdata){
+      var filename = formdata.get("filename");
+      var body = formdata.get("filebody");
+      var response = new Response(body);
+      response.headers.append('Content-Disposition', 'attachment; filename="' + filename + '"');
+        return response;
+      }));
     }
 });

--- a/local-download/service-worker.js
+++ b/local-download/service-worker.js
@@ -4,7 +4,7 @@
 self.addEventListener('fetch', function(event) {
     // If the request is going to the download-file endpoint, parse the post data and return a file. 
     // This can be paired with a server side function with the same behavior as a fallback.
-    if(event.request.url.indexOf("download-file") != -1) {
+    if(event.request.url.indexOf("download-file") !== -1) {
         event.respondWith(event.request.formData().then(function (formdata){
                     var filename = formdata.get("filename");
                     var body = formdata.get("filebody");

--- a/local-download/service-worker.js
+++ b/local-download/service-worker.js
@@ -1,5 +1,6 @@
-// [Working example](/serviceworker-cookbook/DIR-HERE/).
+// [Working example](/serviceworker-cookbook/local-download/).
 
+// Listen on fetch events for posts to download-file
 self.addEventListener('fetch', function(event) {
     // If the request is going to the download-file endpoint, parse the post data and return a file. 
     // This can be paired with a server side function with the same behavior as a fallback.


### PR DESCRIPTION
Added a local download example that accepts a POST request. The serviceworker then sets the header to return a file as an attachment.