### PR TITLE
Fix push-quota

### DIFF
--- a/push-quota/index.js
+++ b/push-quota/index.js
@@ -16,10 +16,11 @@ navigator.serviceWorker.register('service-worker.js')
     // urlBase64ToUint8Array() is defined in /tools.js
     const convertedVapidKey = urlBase64ToUint8Array(vapidPublicKey);
 
-    // Otherwise, subscribe the user (unlike the other push recipes, here we don't set
-    // the userVisibleOnly property because we don't plan to only send notifications that
-    // have a visible effect for the user).
+    // Otherwise, subscribe the user
+    // We are not strictly honoring userVisibleOnly: we will also be sending invisible pushes,
+    // but otherwise Chrome will not allow us to setup a subscription.
     return registration.pushManager.subscribe({
+      userVisibleOnly: true,
       applicationServerKey: convertedVapidKey
     });
   });

--- a/push-quota/server.js
+++ b/push-quota/server.js
@@ -33,7 +33,7 @@ module.exports = function(app, route) {
   // - 'false': don't show a notification.
   app.post(route + 'sendNotification', function(req, res) {
     const subscription = req.body.subscription;
-    const payload = null;
+    const payload = JSON.stringify(req.body.visible);
     const options = {
       TTL: 200
     };


### PR DESCRIPTION
Fix #271

In some previous commit, the payload (`visible = true|false`) got lost so only the "invisible" counter would increment.

Because `userVisibleOnly: true` was not set in the `pushManager.subscribe()` call, Chrome would fail with the following message:
> Chrome currently only supports the Push API for subscriptions that will result in user-visible messages. You can indicate this by calling pushManager.subscribe({userVisibleOnly: true}) instead. See https://goo.gl/yqv4Q4 for more details.

Setting `userVisibleOnly: true` bypasses this and doesn't actually prevent you from sending invisible pushes.