### PR TITLE
Fix formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ It's online. It's offline. It's a Service Worker!
 
 Service workers are a new technology to aid developers in:
 
-	- creating realistic, reliable offline experiences
-	- vastly improving performance when online
-	- logically and dynamically caching files for any purpose
+- creating realistic, reliable offline experiences
+- vastly improving performance when online
+- logically and dynamically caching files for any purpose
 
 The ServiceWorker API, which has recently made its way into Firefox Developer Edition, will change the way web and mobile app developers make their websites fast and functional!
 


### PR DESCRIPTION
This fixes the bullet points so they are rendered as `<li>` instead of a `<code>` block.

Here's a screenshot:

![image](https://user-images.githubusercontent.com/229881/43460901-00c92312-94a0-11e8-87df-783cf7b27399.png)
