### PR TITLE
Update server.js : Disable redirect to serviceworke.rs

### DIFF
--- a/server.js
+++ b/server.js
@@ -29,9 +29,9 @@ app.use(function forceLiveDomain(req, res, next) {
   // Don't allow user to hit Heroku now that we have a domain
   var host = req.get('Host');
 
-  if (host === 'serviceworker-cookbook.herokuapp.com') {
+  /*if (host === 'serviceworker-cookbook.herokuapp.com') {
     return res.redirect(301, 'https://serviceworke.rs');
-  }
+  }*/
   return next();
 });
 


### PR DESCRIPTION
Due to the deactivation of the domain serviceworke.rs, I suggest disabling the redirect to open the site through serviceworker-cookbook.herokuapp.com.