### PR TITLE
security: remove references to https://serviceworke.rs/

### DIFF
--- a/push-clients/server.js
+++ b/push-clients/server.js
@@ -2,41 +2,44 @@
 // between the application server and the push service.
 // For details, see https://tools.ietf.org/html/draft-ietf-webpush-protocol and
 // https://tools.ietf.org/html/draft-ietf-webpush-encryption.
-const webPush = require('web-push');
+const webPush = require("web-push");
 
 if (!process.env.VAPID_PUBLIC_KEY || !process.env.VAPID_PRIVATE_KEY) {
-  console.log("You must set the VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY "+
-    "environment variables. You can use the following ones:");
+  console.log(
+    "You must set the VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY " +
+      "environment variables. You can use the following ones:"
+  );
   console.log(webPush.generateVAPIDKeys());
   return;
 }
 // Set the keys used for encrypting the push messages.
 webPush.setVapidDetails(
-  'https://serviceworke.rs/',
+  "https://example.com/",
   process.env.VAPID_PUBLIC_KEY,
   process.env.VAPID_PRIVATE_KEY
 );
 
-module.exports = function(app, route) {
-  app.get(route + 'vapidPublicKey', function(req, res) {
+module.exports = function (app, route) {
+  app.get(route + "vapidPublicKey", function (req, res) {
     res.send(process.env.VAPID_PUBLIC_KEY);
   });
 
-  app.post(route + 'register', function(req, res) {
+  app.post(route + "register", function (req, res) {
     // A real world application would store the subscription info.
     res.sendStatus(201);
   });
 
-  app.post(route + 'sendNotification', function(req, res) {
-    setTimeout(function() {
-      webPush.sendNotification(req.body.subscription)
-      .then(function() {
-        res.sendStatus(201);
-      })
-      .catch(function(error) {
-        res.sendStatus(500);
-        console.log(error);
-      });
+  app.post(route + "sendNotification", function (req, res) {
+    setTimeout(function () {
+      webPush
+        .sendNotification(req.body.subscription)
+        .then(function () {
+          res.sendStatus(201);
+        })
+        .catch(function (error) {
+          res.sendStatus(500);
+          console.log(error);
+        });
     }, 10000);
   });
 };

--- a/push-get-payload/server.js
+++ b/push-get-payload/server.js
@@ -2,54 +2,57 @@
 // between the application server and the push service.
 // For details, see https://tools.ietf.org/html/draft-ietf-webpush-protocol and
 // https://tools.ietf.org/html/draft-ietf-webpush-encryption.
-const webPush = require('web-push');
+const webPush = require("web-push");
 
 if (!process.env.VAPID_PUBLIC_KEY || !process.env.VAPID_PRIVATE_KEY) {
-  console.log("You must set the VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY "+
-    "environment variables. You can use the following ones:");
+  console.log(
+    "You must set the VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY " +
+      "environment variables. You can use the following ones:"
+  );
   console.log(webPush.generateVAPIDKeys());
   return;
 }
 // Set the keys used for encrypting the push messages.
 webPush.setVapidDetails(
-  'https://serviceworke.rs/',
+  "https://example.com/",
   process.env.VAPID_PUBLIC_KEY,
   process.env.VAPID_PRIVATE_KEY
 );
 
 const payloads = {};
 
-module.exports = function(app, route) {
-  app.get(route + 'vapidPublicKey', function(req, res) {
+module.exports = function (app, route) {
+  app.get(route + "vapidPublicKey", function (req, res) {
     res.send(process.env.VAPID_PUBLIC_KEY);
   });
 
-  app.post(route + 'register', function(req, res) {
+  app.post(route + "register", function (req, res) {
     // A real world application would store the subscription info.
     res.sendStatus(201);
   });
 
-  app.post(route + 'sendNotification', function(req, res) {
+  app.post(route + "sendNotification", function (req, res) {
     const subscription = req.body.subscription;
     const payload = req.body.payload;
     const options = {
-      TTL: req.body.ttl
+      TTL: req.body.ttl,
     };
 
-    setTimeout(function() {
+    setTimeout(function () {
       payloads[req.body.subscription.endpoint] = payload;
-      webPush.sendNotification(subscription, null, options)
-      .then(function() {
-        res.sendStatus(201);
-      })
-      .catch(function(error) {
-        res.sendStatus(500);
-        console.log(error);
-      });
+      webPush
+        .sendNotification(subscription, null, options)
+        .then(function () {
+          res.sendStatus(201);
+        })
+        .catch(function (error) {
+          res.sendStatus(500);
+          console.log(error);
+        });
     }, req.body.delay * 1000);
   });
 
-  app.get(route + 'getPayload', function(req, res) {
+  app.get(route + "getPayload", function (req, res) {
     res.send(payloads[req.query.endpoint]);
   });
 };

--- a/push-payload/server.js
+++ b/push-payload/server.js
@@ -2,47 +2,50 @@
 // between the application server and the push service.
 // For details, see https://tools.ietf.org/html/draft-ietf-webpush-protocol and
 // https://tools.ietf.org/html/draft-ietf-webpush-encryption.
-const webPush = require('web-push');
+const webPush = require("web-push");
 
 if (!process.env.VAPID_PUBLIC_KEY || !process.env.VAPID_PRIVATE_KEY) {
-  console.log("You must set the VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY "+
-    "environment variables. You can use the following ones:");
+  console.log(
+    "You must set the VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY " +
+      "environment variables. You can use the following ones:"
+  );
   console.log(webPush.generateVAPIDKeys());
   return;
 }
 // Set the keys used for encrypting the push messages.
 webPush.setVapidDetails(
-  'https://serviceworke.rs/',
+  "https://example.com/",
   process.env.VAPID_PUBLIC_KEY,
   process.env.VAPID_PRIVATE_KEY
 );
 
-module.exports = function(app, route) {
-  app.get(route + 'vapidPublicKey', function(req, res) {
+module.exports = function (app, route) {
+  app.get(route + "vapidPublicKey", function (req, res) {
     res.send(process.env.VAPID_PUBLIC_KEY);
   });
 
-  app.post(route + 'register', function(req, res) {
+  app.post(route + "register", function (req, res) {
     // A real world application would store the subscription info.
     res.sendStatus(201);
   });
 
-  app.post(route + 'sendNotification', function(req, res) {
+  app.post(route + "sendNotification", function (req, res) {
     const subscription = req.body.subscription;
     const payload = req.body.payload;
     const options = {
-      TTL: req.body.ttl
+      TTL: req.body.ttl,
     };
 
-    setTimeout(function() {
-      webPush.sendNotification(subscription, payload, options)
-      .then(function() {
-        res.sendStatus(201);
-      })
-      .catch(function(error) {
-        console.log(error);
-        res.sendStatus(500);
-      });
+    setTimeout(function () {
+      webPush
+        .sendNotification(subscription, payload, options)
+        .then(function () {
+          res.sendStatus(201);
+        })
+        .catch(function (error) {
+          console.log(error);
+          res.sendStatus(500);
+        });
     }, req.body.delay * 1000);
   });
 };

--- a/push-quota/server.js
+++ b/push-quota/server.js
@@ -2,27 +2,29 @@
 // between the application server and the push service.
 // For details, see https://tools.ietf.org/html/draft-ietf-webpush-protocol and
 // https://tools.ietf.org/html/draft-ietf-webpush-encryption.
-const webPush = require('web-push');
+const webPush = require("web-push");
 
 if (!process.env.VAPID_PUBLIC_KEY || !process.env.VAPID_PRIVATE_KEY) {
-  console.log("You must set the VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY "+
-    "environment variables. You can use the following ones:");
+  console.log(
+    "You must set the VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY " +
+      "environment variables. You can use the following ones:"
+  );
   console.log(webPush.generateVAPIDKeys());
   return;
 }
 // Set the keys used for encrypting the push messages.
 webPush.setVapidDetails(
-  'https://serviceworke.rs/',
+  "https://example.com/",
   process.env.VAPID_PUBLIC_KEY,
   process.env.VAPID_PRIVATE_KEY
 );
 
-module.exports = function(app, route) {
-  app.get(route + 'vapidPublicKey', function(req, res) {
+module.exports = function (app, route) {
+  app.get(route + "vapidPublicKey", function (req, res) {
     res.send(process.env.VAPID_PUBLIC_KEY);
   });
 
-  app.post(route + 'register', function(req, res) {
+  app.post(route + "register", function (req, res) {
     // A real world application would store the subscription info.
     res.sendStatus(201);
   });
@@ -31,31 +33,31 @@ module.exports = function(app, route) {
   // a visible notification or not using the push payload:
   // - 'true': show a notification;
   // - 'false': don't show a notification.
-  app.post(route + 'sendNotification', function(req, res) {
+  app.post(route + "sendNotification", function (req, res) {
     const subscription = req.body.subscription;
     const payload = JSON.stringify(req.body.visible);
     const options = {
-      TTL: 200
+      TTL: 200,
     };
 
     let num = 1;
 
     let promises = [];
 
-    let intervalID = setInterval(function() {
+    let intervalID = setInterval(function () {
       promises.push(webPush.sendNotification(subscription, payload, options));
 
       if (num++ === Number(req.body.num)) {
         clearInterval(intervalID);
 
         Promise.all(promises)
-        .then(function() {
-          res.sendStatus(201);
-        })
-        .catch(function(error) {
-          res.sendStatus(500);
-          console.log(error);
-        })
+          .then(function () {
+            res.sendStatus(201);
+          })
+          .catch(function (error) {
+            res.sendStatus(500);
+            console.log(error);
+          });
       }
     }, 1000);
   });

--- a/push-replace/server.js
+++ b/push-replace/server.js
@@ -2,47 +2,49 @@
 // between the application server and the push service.
 // For details, see https://tools.ietf.org/html/draft-ietf-webpush-protocol and
 // https://tools.ietf.org/html/draft-ietf-webpush-encryption.
-const webPush = require('web-push');
+const webPush = require("web-push");
 
 if (!process.env.VAPID_PUBLIC_KEY || !process.env.VAPID_PRIVATE_KEY) {
-  console.log("You must set the VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY "+
-    "environment variables. You can use the following ones:");
+  console.log(
+    "You must set the VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY " +
+      "environment variables. You can use the following ones:"
+  );
   console.log(webPush.generateVAPIDKeys());
   return;
 }
 // Set the keys used for encrypting the push messages.
 webPush.setVapidDetails(
-  'https://serviceworke.rs/',
+  "https://example.com/",
   process.env.VAPID_PUBLIC_KEY,
   process.env.VAPID_PRIVATE_KEY
 );
 
-module.exports = function(app, route) {
-  app.get(route + 'vapidPublicKey', function(req, res) {
+module.exports = function (app, route) {
+  app.get(route + "vapidPublicKey", function (req, res) {
     res.send(process.env.VAPID_PUBLIC_KEY);
   });
 
-  app.post(route + 'register', function(req, res) {
+  app.post(route + "register", function (req, res) {
     // A real world application would store the subscription info.
     res.sendStatus(201);
   });
 
-  app.post(route + 'sendNotification', function(req, res) {
+  app.post(route + "sendNotification", function (req, res) {
     const subscription = req.body.subscription;
     const payload = null;
     const options = {
-      TTL: 200
+      TTL: 200,
     };
 
-    webPush.sendNotification(subscription, payload, options)
-    .catch(logError);
+    webPush.sendNotification(subscription, payload, options).catch(logError);
 
-    setTimeout(function() {
-      webPush.sendNotification(subscription, payload, options)
-      .then(function() {
-        res.sendStatus(201);
-      })
-      .catch(logError);
+    setTimeout(function () {
+      webPush
+        .sendNotification(subscription, payload, options)
+        .then(function () {
+          res.sendStatus(201);
+        })
+        .catch(logError);
     }, req.body.delay * 1000);
 
     function logError(error) {

--- a/push-rich/server.js
+++ b/push-rich/server.js
@@ -2,47 +2,50 @@
 // between the application server and the push service.
 // For details, see https://tools.ietf.org/html/draft-ietf-webpush-protocol and
 // https://tools.ietf.org/html/draft-ietf-webpush-encryption.
-const webPush = require('web-push');
+const webPush = require("web-push");
 
 if (!process.env.VAPID_PUBLIC_KEY || !process.env.VAPID_PRIVATE_KEY) {
-  console.log("You must set the VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY "+
-    "environment variables. You can use the following ones:");
+  console.log(
+    "You must set the VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY " +
+      "environment variables. You can use the following ones:"
+  );
   console.log(webPush.generateVAPIDKeys());
   return;
 }
 // Set the keys used for encrypting the push messages.
 webPush.setVapidDetails(
-  'https://serviceworke.rs/',
+  "https://example.com/",
   process.env.VAPID_PUBLIC_KEY,
   process.env.VAPID_PRIVATE_KEY
 );
 
-module.exports = function(app, route) {
-  app.get(route + 'vapidPublicKey', function(req, res) {
+module.exports = function (app, route) {
+  app.get(route + "vapidPublicKey", function (req, res) {
     res.send(process.env.VAPID_PUBLIC_KEY);
   });
 
-  app.post(route + 'register', function(req, res) {
+  app.post(route + "register", function (req, res) {
     // A real world application would store the subscription info.
     res.sendStatus(201);
   });
 
-  app.post(route + 'sendNotification', function(req, res) {
+  app.post(route + "sendNotification", function (req, res) {
     const subscription = req.body.subscription;
     const payload = null;
     const options = {
-      TTL: req.body.ttl
+      TTL: req.body.ttl,
     };
 
-    setTimeout(function() {
-      webPush.sendNotification(subscription, payload, options)
-      .then(function() {
-        res.sendStatus(201);
-      })
-      .catch(function(error) {
-        console.log(error);
-        res.sendStatus(500);
-      });
+    setTimeout(function () {
+      webPush
+        .sendNotification(subscription, payload, options)
+        .then(function () {
+          res.sendStatus(201);
+        })
+        .catch(function (error) {
+          console.log(error);
+          res.sendStatus(500);
+        });
     }, req.body.delay * 1000);
   });
 };

--- a/push-simple/server.js
+++ b/push-simple/server.js
@@ -2,47 +2,50 @@
 // between the application server and the push service.
 // For details, see https://tools.ietf.org/html/draft-ietf-webpush-protocol and
 // https://tools.ietf.org/html/draft-ietf-webpush-encryption.
-const webPush = require('web-push');
+const webPush = require("web-push");
 
 if (!process.env.VAPID_PUBLIC_KEY || !process.env.VAPID_PRIVATE_KEY) {
-  console.log("You must set the VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY "+
-    "environment variables. You can use the following ones:");
+  console.log(
+    "You must set the VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY " +
+      "environment variables. You can use the following ones:"
+  );
   console.log(webPush.generateVAPIDKeys());
   return;
 }
 // Set the keys used for encrypting the push messages.
 webPush.setVapidDetails(
-  'https://serviceworke.rs/',
+  "https://example.com/",
   process.env.VAPID_PUBLIC_KEY,
   process.env.VAPID_PRIVATE_KEY
 );
 
-module.exports = function(app, route) {
-  app.get(route + 'vapidPublicKey', function(req, res) {
+module.exports = function (app, route) {
+  app.get(route + "vapidPublicKey", function (req, res) {
     res.send(process.env.VAPID_PUBLIC_KEY);
   });
 
-  app.post(route + 'register', function(req, res) {
+  app.post(route + "register", function (req, res) {
     // A real world application would store the subscription info.
     res.sendStatus(201);
   });
 
-  app.post(route + 'sendNotification', function(req, res) {
+  app.post(route + "sendNotification", function (req, res) {
     const subscription = req.body.subscription;
     const payload = null;
     const options = {
-      TTL: req.body.ttl
+      TTL: req.body.ttl,
     };
 
-    setTimeout(function() {
-      webPush.sendNotification(subscription, payload, options)
-      .then(function() {
-        res.sendStatus(201);
-      })
-      .catch(function(error) {
-        res.sendStatus(500);
-        console.log(error);
-      });
+    setTimeout(function () {
+      webPush
+        .sendNotification(subscription, payload, options)
+        .then(function () {
+          res.sendStatus(201);
+        })
+        .catch(function (error) {
+          res.sendStatus(500);
+          console.log(error);
+        });
     }, req.body.delay * 1000);
   });
 };

--- a/push-subscription-management/server.js
+++ b/push-subscription-management/server.js
@@ -2,17 +2,19 @@
 // between the application server and the push service.
 // For details, see https://tools.ietf.org/html/draft-ietf-webpush-protocol and
 // https://tools.ietf.org/html/draft-ietf-webpush-encryption.
-const webPush = require('web-push');
+const webPush = require("web-push");
 
 if (!process.env.VAPID_PUBLIC_KEY || !process.env.VAPID_PRIVATE_KEY) {
-  console.log("You must set the VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY "+
-    "environment variables. You can use the following ones:");
+  console.log(
+    "You must set the VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY " +
+      "environment variables. You can use the following ones:"
+  );
   console.log(webPush.generateVAPIDKeys());
   return;
 }
 // Set the keys used for encrypting the push messages.
 webPush.setVapidDetails(
-  'https://serviceworke.rs/',
+  "https://example.com/",
   process.env.VAPID_PUBLIC_KEY,
   process.env.VAPID_PRIVATE_KEY
 );
@@ -29,42 +31,50 @@ const pushInterval = 10;
 // `subscriptions` array if the  push service responds with an error.
 // Subscription has been cancelled or expired.
 function sendNotification(subscription) {
-  webPush.sendNotification(subscription)
-  .then(function() {
-    console.log('Push Application Server - Notification sent to ' + subscription.endpoint);
-  }).catch(function() {
-    console.log('ERROR in sending Notification, endpoint removed ' + subscription.endpoint);
-    delete subscriptions[subscription.endpoint];
-  });
+  webPush
+    .sendNotification(subscription)
+    .then(function () {
+      console.log(
+        "Push Application Server - Notification sent to " +
+          subscription.endpoint
+      );
+    })
+    .catch(function () {
+      console.log(
+        "ERROR in sending Notification, endpoint removed " +
+          subscription.endpoint
+      );
+      delete subscriptions[subscription.endpoint];
+    });
 }
 
 // In real world application is sent only if an event occured.
 // To simulate it, server is sending a notification every `pushInterval` seconds
 // to each registered endpoint.
-setInterval(function() {
+setInterval(function () {
   Object.values(subscriptions).forEach(sendNotification);
 }, pushInterval * 1000);
 
-module.exports = function(app, route) {
-  app.get(route + 'vapidPublicKey', function(req, res) {
+module.exports = function (app, route) {
+  app.get(route + "vapidPublicKey", function (req, res) {
     res.send(process.env.VAPID_PUBLIC_KEY);
   });
 
   // Register a subscription by adding it to the `subscriptions` array.
-  app.post(route + 'register', function(req, res) {
+  app.post(route + "register", function (req, res) {
     var subscription = req.body.subscription;
     if (!subscriptions[subscription.endpoint]) {
-      console.log('Subscription registered ' + subscription.endpoint);
+      console.log("Subscription registered " + subscription.endpoint);
       subscriptions[subscription.endpoint] = subscription;
     }
     res.sendStatus(201);
   });
 
   // Unregister a subscription by removing it from the `subscriptions` array
-  app.post(route + 'unregister', function(req, res) {
+  app.post(route + "unregister", function (req, res) {
     var subscription = req.body.subscription;
     if (subscriptions[subscription.endpoint]) {
-      console.log('Subscription unregistered ' + subscription.endpoint);
+      console.log("Subscription unregistered " + subscription.endpoint);
       delete subscriptions[subscription.endpoint];
     }
     res.sendStatus(201);


### PR DESCRIPTION
The domain https://serviceworke.rs/ (do not open) has been overtaken and are used to steal clicks.
This removes the domain and uses a dummy domain.
